### PR TITLE
Fix server crash due to referencing client classes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings      = 1.20.1+build.8
 loader_version     = 0.14.21
 
 # Mod Properties
-mod_version        = 1.4.1
+mod_version        = 1.4.2
 maven_group        = ooo.foooooooooooo
 archives_base_name = wicked-paintings
 

--- a/src/main/java/ooo/foooooooooooo/wickedpaintings/WickedPaintings.java
+++ b/src/main/java/ooo/foooooooooooo/wickedpaintings/WickedPaintings.java
@@ -7,8 +7,6 @@ import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.inventory.StackReference;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
@@ -36,7 +34,7 @@ public class WickedPaintings implements ModInitializer {
     .build();
 
   public static final Logger LOGGERS = LoggerFactory.getLogger(WickedPaintings.class);
-  public static ScreenHandlerType<WickedGuiDescription> WICKED_SCREEN_HANDLER_TYPE;
+  public static final ScreenHandlerType<WickedGuiDescription> WICKED_SCREEN_HANDLER_TYPE = new ExtendedScreenHandlerType<>(WickedGuiDescription::new);
 
   @Override
   public void onInitialize() {
@@ -44,13 +42,6 @@ public class WickedPaintings implements ModInitializer {
     AutoConfig.register(ModConfig.class, JanksonConfigSerializer::new);
 
     Registry.register(Registries.ITEM_GROUP, ITEM_GROUP_KEY, ITEM_GROUP);
-
-    WICKED_SCREEN_HANDLER_TYPE = new ExtendedScreenHandlerType<>((syncId, inventory, buf) -> {
-      var equipmentSlot = buf.readEnumConstant(EquipmentSlot.class);
-      var handStack = StackReference.of(inventory.player, equipmentSlot);
-      return new WickedGuiDescription(syncId, inventory, handStack);
-    });
-
     Registry.register(Registries.SCREEN_HANDLER, new Identifier(MOD_ID, "wicked_gui"), WICKED_SCREEN_HANDLER_TYPE);
 
     ModEntityTypes.registerEntityTypes();

--- a/src/main/java/ooo/foooooooooooo/wickedpaintings/WickedPaintingsClient.java
+++ b/src/main/java/ooo/foooooooooooo/wickedpaintings/WickedPaintingsClient.java
@@ -1,12 +1,11 @@
 package ooo.foooooooooooo.wickedpaintings;
 
-import io.github.cottonmc.cotton.gui.client.CottonInventoryScreen;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
-import ooo.foooooooooooo.wickedpaintings.client.screen.WickedGuiDescription;
+import ooo.foooooooooooo.wickedpaintings.client.screen.WickedPaintingScreen;
 import ooo.foooooooooooo.wickedpaintings.config.ModConfig;
 import ooo.foooooooooooo.wickedpaintings.entity.ModEntityTypes;
 import ooo.foooooooooooo.wickedpaintings.network.ModNetworking;
@@ -17,10 +16,7 @@ public class WickedPaintingsClient implements ClientModInitializer {
 
   @Override
   public void onInitializeClient() {
-    //noinspection RedundantTypeArguments fails to build if you remove these types
-    HandledScreens.<WickedGuiDescription, CottonInventoryScreen<WickedGuiDescription>>register(WickedPaintings.WICKED_SCREEN_HANDLER_TYPE,
-      CottonInventoryScreen::new
-    );
+    HandledScreens.register(WickedPaintings.WICKED_SCREEN_HANDLER_TYPE, WickedPaintingScreen::new);
     ModEntityTypes.registerRenderers();
     ModNetworking.registerClientBoundPackets();
   }

--- a/src/main/java/ooo/foooooooooooo/wickedpaintings/client/screen/WickedGuiDescription.java
+++ b/src/main/java/ooo/foooooooooooo/wickedpaintings/client/screen/WickedGuiDescription.java
@@ -1,131 +1,23 @@
 package ooo.foooooooooooo.wickedpaintings.client.screen;
 
 import io.github.cottonmc.cotton.gui.ItemSyncedGuiDescription;
-import io.github.cottonmc.cotton.gui.widget.*;
-import io.github.cottonmc.cotton.gui.widget.data.HorizontalAlignment;
-import io.github.cottonmc.cotton.gui.widget.data.Insets;
-import io.github.cottonmc.cotton.gui.widget.data.VerticalAlignment;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.resource.language.I18n;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.StackReference;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
-import ooo.foooooooooooo.wickedpaintings.NbtConstants;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
 import ooo.foooooooooooo.wickedpaintings.WickedPaintings;
-import ooo.foooooooooooo.wickedpaintings.WickedPaintingsClient;
-import ooo.foooooooooooo.wickedpaintings.network.ServerBoundPackets;
-
-import static ooo.foooooooooooo.wickedpaintings.util.ImageUtils.*;
 
 public class WickedGuiDescription extends ItemSyncedGuiDescription {
-  private final ImageWidget imageWidget;
-  private final int selectedSlot;
-  private boolean invalidUrl = false;
-  private Identifier imageId = DEFAULT_TEX;
-
-  public WickedGuiDescription(int syncId, PlayerInventory playerInventory, StackReference stackRef) {
-    super(WickedPaintings.WICKED_SCREEN_HANDLER_TYPE, syncId, playerInventory, stackRef);
-
-    selectedSlot = playerInventory.selectedSlot;
-    var stack = stackRef.get();
-
-    var root = new WGridPanel(9);
-
-    var nbt = stack.getOrCreateNbt();
-
-    var url = nbt.getString(NbtConstants.URL);
-    var imageId = Identifier.tryParse(nbt.getString(NbtConstants.IMAGE_ID));
-
-    setRootPanel(root);
-
-    var guiWidth = 36;
-
-    root.setInsets(Insets.ROOT_PANEL);
-
-    var widthLabel = new WLabel(Text.translatable("gui.wicked_paintings.image_width"));
-    widthLabel.setVerticalAlignment(VerticalAlignment.CENTER);
-    root.add(widthLabel, 0, 4, 10, 2);
-
-    var widthField = new WTextField(Text.translatable("gui.wicked_paintings.image_width_placeholder"));
-    widthField.setTextPredicate((text) -> text.matches("[0-9]+") && text.length() <= 2);
-    widthField.setText(String.valueOf(nbt.getInt(NbtConstants.WIDTH)));
-    root.add(widthField, 9, 4, 4, 2);
-
-    var heightLabel = new WLabel(Text.translatable("gui.wicked_paintings.image_height"));
-    heightLabel.setVerticalAlignment(VerticalAlignment.CENTER);
-    root.add(heightLabel, 0, 7, 10, 2);
-
-    var heightField = new WTextField(Text.translatable("gui.wicked_paintings.image_height_placeholder"));
-    heightField.setTextPredicate((text) -> text.matches("[0-9]+") && text.length() <= 2);
-    heightField.setText(String.valueOf(nbt.getInt(NbtConstants.HEIGHT)));
-    root.add(heightField, 9, 7, 4, 2);
-
-    var imageWidget = new ImageWidget(imageId);
-    imageWidget.setTexture(imageId);
-    imageWidget.setSize(90, 90);
-    this.imageWidget = imageWidget;
-    root.add(imageWidget, guiWidth - 10, 1, 10, 10);
-
-    var title = new WLabel(Text.translatable("gui.wicked_paintings.title"), 0x0);
-    title.setHorizontalAlignment(HorizontalAlignment.CENTER);
-    root.add(title, 0, 0, guiWidth, 1);
-
-    var urlField = new WTextField(Text.translatable("gui.wicked_paintings.url_placeholder"));
-    urlField.setMaxLength(512);
-    urlField.setText(url);
-    root.add(urlField, 0, 12, guiWidth, 2);
-
-    if (WickedPaintingsClient.CONFIG.debug) {
-      var debugLabel = new WDynamicLabel(() -> this.imageId.toString());
-      root.add(debugLabel, 0, 10, 0, 1);
+    public WickedGuiDescription(int syncId, PlayerInventory inventory, PacketByteBuf buffer) {
+        this(syncId, inventory, StackReference.of(inventory.player, buffer.readEnumConstant(EquipmentSlot.class)));
     }
 
-    var urlLabel = new WDynamicLabel(() -> invalidUrl ? I18n.translate("gui.wicked_paintings.url_label_invalid") : "");
-    urlLabel.setColor(0xFF0F0F, 0xFF1F1F);
-    root.add(urlLabel, 0, 16, 0, 1);
-
-    var loadButton = new WButton(Text.translatable("gui.wicked_paintings.load_button"));
-    loadButton.setOnClick(() -> onLoad(urlField.getText()));
-    root.add(loadButton, guiWidth - 9, 16, 4, 2);
-
-    var applyButton = new WButton(Text.translatable("gui.wicked_paintings.apply_button"));
-    applyButton.setOnClick(() -> onApply(urlField.getText(), parseField(widthField.getText(), 1), parseField(heightField.getText(), 1)));
-
-    root.add(applyButton, guiWidth - 4, 16, 4, 2);
-
-    root.validate(this);
-  }
-
-  public void onLoad(String url) {
-    imageId = getOrLoadImage(generateImageId(url), url);
-    setTexture(imageId);
-
-    invalidUrl = imageId == DEFAULT_TEX;
-  }
-
-  public void onApply(String url, int width, int height) {
-    if (url.isEmpty()) {
-      invalidUrl = true;
-      return;
+    public WickedGuiDescription(int syncId, PlayerInventory playerInventory, StackReference stackRef) {
+        super(WickedPaintings.WICKED_SCREEN_HANDLER_TYPE, syncId, playerInventory, stackRef);
     }
 
-    onLoad(url);
-
-    ServerBoundPackets.sendWickedUpdate(selectedSlot, url, imageId, width, height);
-
-    MinecraftClient.getInstance().setScreen(null);
-  }
-
-  public int parseField(String text, int defaultValue) {
-    try {
-      return Integer.parseInt(text);
-    } catch (NumberFormatException e) {
-      return defaultValue;
+    public ItemStack getStack() {
+        return ownerStack;
     }
-  }
-
-  public void setTexture(Identifier texture) {
-    this.imageWidget.setTexture(texture);
-  }
 }

--- a/src/main/java/ooo/foooooooooooo/wickedpaintings/client/screen/WickedPaintingScreen.java
+++ b/src/main/java/ooo/foooooooooooo/wickedpaintings/client/screen/WickedPaintingScreen.java
@@ -1,0 +1,142 @@
+package ooo.foooooooooooo.wickedpaintings.client.screen;
+
+import static ooo.foooooooooooo.wickedpaintings.util.ImageUtils.DEFAULT_TEX;
+import static ooo.foooooooooooo.wickedpaintings.util.ImageUtils.generateImageId;
+import static ooo.foooooooooooo.wickedpaintings.util.ImageUtils.getOrLoadImage;
+
+import io.github.cottonmc.cotton.gui.client.CottonInventoryScreen;
+import io.github.cottonmc.cotton.gui.widget.WButton;
+import io.github.cottonmc.cotton.gui.widget.WDynamicLabel;
+import io.github.cottonmc.cotton.gui.widget.WGridPanel;
+import io.github.cottonmc.cotton.gui.widget.WLabel;
+import io.github.cottonmc.cotton.gui.widget.WTextField;
+import io.github.cottonmc.cotton.gui.widget.data.HorizontalAlignment;
+import io.github.cottonmc.cotton.gui.widget.data.Insets;
+import io.github.cottonmc.cotton.gui.widget.data.VerticalAlignment;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import ooo.foooooooooooo.wickedpaintings.NbtConstants;
+import ooo.foooooooooooo.wickedpaintings.WickedPaintingsClient;
+import ooo.foooooooooooo.wickedpaintings.network.ServerBoundPackets;
+
+public class WickedPaintingScreen extends CottonInventoryScreen<WickedGuiDescription> {
+    private final ImageWidget imageWidget;
+
+    private boolean invalidUrl = false;
+    private Identifier imageId = DEFAULT_TEX;
+
+    private final int selectedSlot;
+
+    public WickedPaintingScreen(WickedGuiDescription description, PlayerInventory inventory, Text titleText) {
+        super(description, inventory, titleText);
+
+        selectedSlot = inventory.selectedSlot;
+
+        var stack = description.getStack();
+
+        var root = new WGridPanel(9);
+
+        var nbt = stack.getOrCreateNbt();
+
+        var url = nbt.getString(NbtConstants.URL);
+        var imageId = Identifier.tryParse(nbt.getString(NbtConstants.IMAGE_ID));
+
+        description.setRootPanel(root);
+
+        var guiWidth = 36;
+
+        root.setInsets(Insets.ROOT_PANEL);
+
+        var widthLabel = new WLabel(Text.translatable("gui.wicked_paintings.image_width"));
+        widthLabel.setVerticalAlignment(VerticalAlignment.CENTER);
+        root.add(widthLabel, 0, 4, 10, 2);
+
+        var widthField = new WTextField(Text.translatable("gui.wicked_paintings.image_width_placeholder"));
+        widthField.setTextPredicate((text) -> text.matches("[0-9]+") && text.length() <= 2);
+        widthField.setText(String.valueOf(nbt.getInt(NbtConstants.WIDTH)));
+        root.add(widthField, 9, 4, 4, 2);
+
+        var heightLabel = new WLabel(Text.translatable("gui.wicked_paintings.image_height"));
+        heightLabel.setVerticalAlignment(VerticalAlignment.CENTER);
+        root.add(heightLabel, 0, 7, 10, 2);
+
+        var heightField = new WTextField(Text.translatable("gui.wicked_paintings.image_height_placeholder"));
+        heightField.setTextPredicate((text) -> text.matches("[0-9]+") && text.length() <= 2);
+        heightField.setText(String.valueOf(nbt.getInt(NbtConstants.HEIGHT)));
+        root.add(heightField, 9, 7, 4, 2);
+
+        var imageWidget = new ImageWidget(imageId);
+        imageWidget.setTexture(imageId);
+        imageWidget.setSize(90, 90);
+        this.imageWidget = imageWidget;
+        root.add(imageWidget, guiWidth - 10, 1, 10, 10);
+
+        var title = new WLabel(Text.translatable("gui.wicked_paintings.title"), 0x0);
+        title.setHorizontalAlignment(HorizontalAlignment.CENTER);
+        root.add(title, 0, 0, guiWidth, 1);
+
+        var urlField = new WTextField(Text.translatable("gui.wicked_paintings.url_placeholder"));
+        urlField.setMaxLength(512);
+        urlField.setText(url);
+        root.add(urlField, 0, 12, guiWidth, 2);
+
+        if (WickedPaintingsClient.CONFIG.debug) {
+            root.add(new WDynamicLabel(() -> this.imageId.toString()), 0, 10, 0, 1);
+        }
+
+        var urlLabel = new WDynamicLabel(() -> invalidUrl ? I18n.translate("gui.wicked_paintings.url_label_invalid") : "");
+        urlLabel.setColor(0xFF0F0F, 0xFF1F1F);
+        root.add(urlLabel, 0, 16, 0, 1);
+
+        var loadButton = new WButton(Text.translatable("gui.wicked_paintings.load_button"));
+        root.add(loadButton, guiWidth - 9, 16, 4, 2);
+
+        var applyButton = new WButton(Text.translatable("gui.wicked_paintings.apply_button"));
+
+        root.add(applyButton, guiWidth - 4, 16, 4, 2);
+
+        root.validate(description);
+
+        loadButton.setOnClick(() -> onLoad(urlField.getText()));
+        applyButton.setOnClick(() -> onApply(
+                urlField.getText(),
+                parseField(widthField.getText(), 1),
+                parseField(heightField.getText(), 1)
+                ));
+    }
+
+    public void setTexture(Identifier texture) {
+
+    }
+
+    public void onLoad(String url) {
+        imageId = getOrLoadImage(generateImageId(url), url);
+        imageWidget.setTexture(imageId);
+
+        invalidUrl = imageId == DEFAULT_TEX;
+    }
+
+    public void onApply(String url, int width, int height) {
+        if (url.isEmpty()) {
+            invalidUrl = true;
+            return;
+        }
+
+        onLoad(url);
+
+        ServerBoundPackets.sendWickedUpdate(selectedSlot, url, imageId, width, height);
+
+        MinecraftClient.getInstance().setScreen(null);
+    }
+
+    public int parseField(String text, int defaultValue) {
+        try {
+            return Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/java/ooo/foooooooooooo/wickedpaintings/item/WickedPaintingItem.java
+++ b/src/main/java/ooo/foooooooooooo/wickedpaintings/item/WickedPaintingItem.java
@@ -1,5 +1,7 @@
 package ooo.foooooooooooo.wickedpaintings.item;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.EntityType;
@@ -36,6 +38,7 @@ public class WickedPaintingItem extends DecorationItem {
     super(ModEntityTypes.WICKED_PAINTING, settings);
   }
 
+  @Override
   public TypedActionResult<ItemStack> use(World world, PlayerEntity player, Hand hand) {
     player.openHandledScreen(createScreenHandlerFactory(player, hand));
     return TypedActionResult.success(player.getStackInHand(hand));
@@ -126,6 +129,7 @@ public class WickedPaintingItem extends DecorationItem {
     }
   }
 
+  @Environment(EnvType.CLIENT)
   @Override
   public void appendTooltip(ItemStack itemStack, World world, List<Text> tooltip, TooltipContext tooltipContext) {
     tooltip.add(Text.translatable(getOrCreateTranslationKey() + ".tooltip"));

--- a/src/main/java/ooo/foooooooooooo/wickedpaintings/util/ImageUtils.java
+++ b/src/main/java/ooo/foooooooooooo/wickedpaintings/util/ImageUtils.java
@@ -1,5 +1,7 @@
 package ooo.foooooooooooo.wickedpaintings.util;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.util.Identifier;
 import ooo.foooooooooooo.wickedpaintings.WickedPaintings;
@@ -13,6 +15,7 @@ public class ImageUtils {
   public static final Identifier DEFAULT_TEX = new Identifier(WickedPaintings.MOD_ID, "textures/block/wicked_painting/default.png");
   public static final Identifier BLOCKED_TEX = new Identifier(WickedPaintings.MOD_ID, "textures/block/wicked_painting/blocked.png");
 
+  @Environment(EnvType.CLIENT)
   public static Identifier getOrLoadImage(Identifier id, String url) {
     var manager = MinecraftClient.getInstance().getTextureManager();
     var texture = manager.getOrDefault(id, null);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "wicked-paintings",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "name": "Wicked Paintings",
   "description": "WICKED paintings",
   "authors": [


### PR DESCRIPTION
Fixes #23 for 1.20.1

Should be able to cherrypick it forward to 1.20.4 if you decide to merge it.

Summary of changes:
1. Moved everything from WickedGuiDescription to WickedPaintingScreen as the description is referenced by server code. All the gui stuff should only happen on the client.
2. Marked ImageUtils#getOrLoadImage and WickedPaintingItem#appendTooltip as client-only methods. I think only the first one is necessary, but I figured it wouldn't hurt to cover both bases.

I considered moving the method to a client package but the annotation worked and this resulted in fewer changes, so figured I'd stick with it. You can make up your mind whether you want to refactor things more.